### PR TITLE
Make postgresql zone configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,4 +16,7 @@ module "web_app" {
   mail_encryption   = var.mail_encryption
   mail_from_address = var.mail_from_address
   admin_email       = var.admin_email
+
+  database_az_enabled = var.database_az_enabled
+  database_az         = var.database_az
 }

--- a/modules/web_app/locals.tf
+++ b/modules/web_app/locals.tf
@@ -36,6 +36,6 @@ locals {
     backup_retention_days         = 7
     geo_redundant_backup_enabled  = false
     public_network_access_enabled = true
-    zone                          = "2"
+    zone                          = var.database_az_enabled ? var.database_az : null
   }
 }

--- a/modules/web_app/variables.tf
+++ b/modules/web_app/variables.tf
@@ -67,3 +67,13 @@ variable "admin_email" {
   description = "Email address of initial admin account"
   type        = string
 }
+
+variable "database_az_enabled" {
+  description = "Specifies if there's a preference for the Availability Zone in which the PostgreSQL Flexible Server should be located"
+  type        = bool
+}
+
+variable "database_az" {
+  description = "Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -78,3 +78,15 @@ variable "admin_email" {
   description = "Email address of initial admin account"
   type        = string
 }
+
+variable "database_az_enabled" {
+  description = "Specifies if there's a preference for the Availability Zone in which the PostgreSQL Flexible Server should be located"
+  type        = bool
+  default     = true
+}
+
+variable "database_az" {
+  description = "Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located"
+  type        = string
+  default     = "2"
+}


### PR DESCRIPTION
This PR makes the `azurerm_postgresql_flexible_server` availability zone argument optional, as some newer Azure accounts seem to not have availability zones enabled this service.

![Screenshot 2023-05-31 at 14 14 41](https://github.com/code4romania/terraform-azure-paul/assets/1569300/3c4494e6-b7a3-4bd0-89ff-d195b9ab8565)

It's not currently clear why this is happening.